### PR TITLE
Fetch instance state (e.g. 'running'/'stopped') for EC2 instances.

### DIFF
--- a/library/Aws/AwsClient.php
+++ b/library/Aws/AwsClient.php
@@ -104,6 +104,7 @@ class AwsClient
                 ));
 
                 $object->monitoring_state = $entry['Monitoring']['State'];
+                $object->status           = $entry['State']['Name'];
                 $object->security_groups  = [];
 
                 foreach ($entry['SecurityGroups'] as $group)

--- a/library/Aws/ProvidedHook/Director/ImportSource.php
+++ b/library/Aws/ProvidedHook/Director/ImportSource.php
@@ -88,6 +88,7 @@ class ImportSource extends ImportSourceHook
                     'private_dns',
                     'monitoring_state',
                     'security_groups',
+                    'status',
                     'tags',
                     'tags.Name',
                     'tags.aws:autoscaling:groupName',


### PR DESCRIPTION
This is a similar solution to the one in #12, but a little simpler and more flexible.
By just storing the state name the user has the choice on what to do with that information.
Using the 'Replace' property modifier to replace 'running' with 'false', and then using the
'MakeBoolean' property modifier to turn the values into booleans ('false' -> false and everything else to true),
the same behavior can be achieved as in #12.