### PR TITLE
Add Route53 Record support

### DIFF
--- a/library/Aws/ProvidedHook/Director/ImportSource.php
+++ b/library/Aws/ProvidedHook/Director/ImportSource.php
@@ -12,11 +12,12 @@ use Icinga\Module\Aws\AwsKey;
 class ImportSource extends ImportSourceHook
 {
     protected static $awsObjectTypes = array(
-        'asg'         => 'Auto Scaling Groups',
-        'lb'          => 'Elastic Load Balancers',
-        'lbv2'        => 'Elastic Load Balancers V2',
-        'ec2instance' => 'EC2 Instances',
-        'rdsinstance' => 'RDS Instances'
+        'asg'            => 'Auto Scaling Groups',
+        'lb'             => 'Elastic Load Balancers',
+        'lbv2'           => 'Elastic Load Balancers V2',
+        'ec2instance'    => 'EC2 Instances',
+        'rdsinstance'    => 'RDS Instances',
+        'route53records' => 'Route53 Records'
     );
 
     protected $db;
@@ -47,6 +48,8 @@ class ImportSource extends ImportSourceHook
                 return $client->getEc2Instances();
             case 'rdsinstance':
                 return $client->getRdsInstances();
+            case 'route53records':
+                return $client->getRoute53Records();
         }
     }
 
@@ -144,6 +147,17 @@ class ImportSource extends ImportSourceHook
                     'tags.aws:cloudformation:stack-id',
                     'tags.aws:cloudformation:stack-name',
                 );
+            case 'route53records':
+                return [
+                    'name',
+                    'recordname',
+                    'type',
+                    'records',
+                    'ttl',
+                    'private_zone',
+                    'zone_name',
+                    'zone_id',
+                ];
         }
     }
 


### PR DESCRIPTION
This PR allows importing route53 records, for example for automatically monitoring websites.

Due to the way the AWS API works, you cannot directly get records, you first have to get all zones and then iterate over each of those to get all records.

Combine the 100 item limit and the rate limiting of the route53 api of 5 req/s, this is quite a slow import if you use hundreds or thousands of zones or records. Nevertheless, it works.