### PR TITLE
DescribeAutoScalingGroups: Increase MaxRecords to 100

### DIFF
--- a/library/Aws/AwsClient.php
+++ b/library/Aws/AwsClient.php
@@ -28,7 +28,9 @@ class AwsClient
     {
         $objects = array();
         $client = $this->sdk()->createAutoScaling();
-        $res = $client->describeAutoScalingGroups();
+        $res = $client->describeAutoScalingGroups([
+            'MaxRecords' => 100
+        ]);
 
         foreach ($res->get('AutoScalingGroups') as $entry) {
 


### PR DESCRIPTION
The default value is 50 and the maximum value is 100.
If we want to have more than 100 records, we have to implement
pagination via `NextToken`.