### PR TITLE
Support PHP 8.5

### DIFF
--- a/library/Aws/AwsClient.php
+++ b/library/Aws/AwsClient.php
@@ -21,7 +21,7 @@ class AwsClient
      */
     protected $sdk;
 
-    public function __construct($key = null, $region)
+    public function __construct($region, $key = null)
     {
         $this->region = $region;
         $this->key = $key;

--- a/library/Aws/ProvidedHook/Director/ImportSource.php
+++ b/library/Aws/ProvidedHook/Director/ImportSource.php
@@ -35,7 +35,7 @@ class ImportSource extends ImportSourceHook
             }
         }
 
-        $client = new AwsClient($key, $this->getSetting('aws_region'));
+        $client = new AwsClient($this->getSetting('aws_region'), $key);
 
         switch ($this->getObjectType()) {
             case 'asg':


### PR DESCRIPTION
Optional parameters before required ones are deprecated since PHP 8.1, so the `AwsClient` and its only usage are adjusted accordingly.

Apart from that everything appears PHP 8.5 compatible.

resolves #58 