### PR TITLE
Drop support for manual installations of the AWS SDK; Composer only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,13 @@
 {
-    "name": "icinga/icingaweb2-module-aws",
-    "config": {
-        "vendor-dir": "library/vendor"
-    },
-    "repositories": [
-    ],
-    "require": {
-        "aws/aws-sdk-php": "3.*"
+  "name": "icinga/icingaweb2-module-aws",
+  "config": {
+    "sort-packages": true,
+    "platform": {
+      "php": "8.2"
     }
+  },
+  "require": {
+    "php": ">=8.2",
+    "aws/aws-sdk-php": "^3.371"
+  }
 }

--- a/doc/02-Installation-and-Configuration.md
+++ b/doc/02-Installation-and-Configuration.md
@@ -19,13 +19,7 @@ Install AWS SDK
 #### Via Composer
 
 For this you need [Composer](https://getcomposer.org/) on your machine. 
-In `/icingaweb2/modules/aws`, run `composer install` and all modules dependencies will be installed. 
-
-#### Manual Install
-
-Next please download and extract the latest v3 standalone ZIP archive from
-the AWS PHP SDK [releases](https://github.com/aws/aws-sdk-php/releases) page.
-You need to extract the AWS PHP SDK v3 to `library/vendor/aws`.
+In `/icingaweb2/modules/aws`, run `composer install` and all modules dependencies will be installed.
 
 AWS IAM role credentials
 ------------------------

--- a/doc/04-Upgrading.md
+++ b/doc/04-Upgrading.md
@@ -1,0 +1,16 @@
+# Upgrading
+
+## Upgrading to version 1.2.0
+
+Manual AWS SDK installations are no longer supported due to missing version constraints.
+**Composer is now the only supported installation method.**
+Additionally, the expected installation path has changed — any existing AWS SDK installation,
+whether manual or via Composer, will be ignored, requiring a fresh installation.
+
+Run the following commands in the module directory to remove previous installations
+and install with appropriate version constraints:
+
+```bash
+rm -rf library/vendor
+composer install --no-dev --optimize-autoloader
+```

--- a/library/Aws/AwsClient.php
+++ b/library/Aws/AwsClient.php
@@ -28,7 +28,6 @@ class AwsClient
     {
         $this->region = $region;
         $this->key = $key;
-        $this->prepareAwsLibs();
     }
 
     public function getAutoscalingConfig()
@@ -358,27 +357,5 @@ class AwsClient
         }
 
         $this->sdk = new Sdk($params);
-    }
-
-    protected function prepareAwsLibs()
-    {
-        if (class_exists('\Aws\Sdk')) {
-            return;
-        }
-
-        $autoloaderFiles = array(
-            dirname(__DIR__) . '/vendor/aws/aws-autoloader.php', // manual sdk installation
-            dirname(__DIR__) . '/vendor/autoload.php',           // composer installation
-        );
-
-        foreach ($autoloaderFiles as $file) {
-            if (file_exists($file)) {
-                require_once $file;
-            }
-        }
-
-        if (! class_exists('\Aws\Sdk')) {
-            throw new \RuntimeException('AWS SDK not found (Class \Aws\Sdk not found)');
-        }
     }
 }

--- a/run.php
+++ b/run.php
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2018 Icinga GmbH <https://icinga.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-namespace Icinga\Module\Aws {
-    $this->provideHook('director/ImportSource');
-}
+require_once __DIR__ . '/vendor/autoload.php';
+
+/** @var $this \Icinga\Application\Modules\Module */
+$this->provideHook('director/ImportSource');


### PR DESCRIPTION
Manual installations do not support version constraints and require additional code. I see no reason to continue supporting this.

Additionally, the expected installation path has changed — any existing AWS SDK installation, whether manual or via Composer, will be ignored, requiring a fresh installation.